### PR TITLE
Added travis CI config + Codebeat analysis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+language: android
+android:
+  components:
+    # Uncomment the lines below if you want to
+    # use the latest revision of Android SDK Tools
+    - tools
+    - platform-tools
+    - tools
+
+    # The BuildTools version used by your project
+    - build-tools-27.0.2
+
+    # The SDK version used to compile your project
+    - android-27
+
+before_script: touch ~/.android/repositories.cfg
+
+notifications:
+  email: false

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Simple Calculator
 <img alt="Logo" src="app/src/main/res/mipmap-xxxhdpi/ic_launcher.png" width="80">
 
+[![Build Status](https://travis-ci.org/jusleg/simple-calculator.svg?branch=master)](https://travis-ci.org/jusleg/simple-calculator) [![codebeat badge](https://codebeat.co/badges/9ce2c059-5bb7-46bd-b512-a746ce275690)](https://codebeat.co/projects/github-com-jusleg-simple-calculator-master)
+
 A calculator with the basic functions and a customizable widget.
 
 You can copy the result or formula to clipboard by long pressing it.
@@ -38,13 +40,13 @@ It contains a couple UI and unit tests, they can be ran with the following instr
 License
 -------
     Copyright 2017 SimpleMobileTools
-    
+
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
-    
+
        http://www.apache.org/licenses/LICENSE-2.0
-    
+
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -37,6 +37,12 @@ android {
         checkReleaseBuilds false
         abortOnError false
     }
+
+    testOptions {
+        unitTests {
+            includeAndroidResources = true
+        }
+    }
 }
 
 dependencies {


### PR DESCRIPTION
**Although the tests are failing, this is a good thing. The square root operation is pretty broken.**
I tried to do a quick fix to make the tests pass but I couldn't because of the unnecessary complexity of the calculator operation handling. In the future, a more streamlined version will have to be used to make the calculator work properly.

The tests are split out into two folders: `androidTest` and `test`. `androidTest` is using Java and has the same, although not exact but 90%+ similar, tests. We should consider removing `androidTest` and focus on the `test` folder which contains Kotlin. Because of this, only the kotlin tests are run on travis CI.

Currently, Travis is building using **API v27**.

Pinging @almiche and @izconcept for review